### PR TITLE
Add configurable AI model settings UI

### DIFF
--- a/esg_tool/ui/app.py
+++ b/esg_tool/ui/app.py
@@ -1,0 +1,203 @@
+"""Flask UI for ESG Tool with configurable AI model settings."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+from flask import Flask, flash, redirect, render_template, request, url_for
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+CONFIG_DIR = ROOT_DIR / "storage" / "config"
+CONFIG_FILE = CONFIG_DIR / "model_settings.json"
+
+
+default_base_url = "https://api.openai.com/v1"
+DEFAULT_SETTINGS = {
+    "provider": "openai",
+    "model_name": "gpt-4-turbo",
+    "base_url": default_base_url,
+    "api_key": "",
+}
+
+AVAILABLE_MODELS = [
+    {
+        "id": "openai-gpt-4-turbo",
+        "label": "OpenAI GPT-4 Turbo",
+        "provider": "openai",
+        "model_name": "gpt-4-turbo",
+        "base_url": "https://api.openai.com/v1",
+    },
+    {
+        "id": "openai-gpt-4o-mini",
+        "label": "OpenAI GPT-4o Mini",
+        "provider": "openai",
+        "model_name": "gpt-4o-mini",
+        "base_url": "https://api.openai.com/v1",
+    },
+    {
+        "id": "anthropic-claude-3-sonnet",
+        "label": "Anthropic Claude 3 Sonnet",
+        "provider": "anthropic",
+        "model_name": "claude-3-sonnet-20240229",
+        "base_url": "https://api.anthropic.com",
+    },
+]
+
+
+@dataclass
+class AgentConfig:
+    """Runtime configuration for an AI powered agent."""
+
+    name: str
+    provider: str
+    model_name: str
+    api_key: str
+    base_url: Optional[str] = None
+
+    def as_dict(self) -> Dict[str, Optional[str]]:
+        return {
+            "name": self.name,
+            "provider": self.provider,
+            "model_name": self.model_name,
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+        }
+
+
+class WorkflowService:
+    """Initialises agents with the currently selected model settings."""
+
+    def __init__(self) -> None:
+        self.settings = DEFAULT_SETTINGS.copy()
+        self.agents: Dict[str, AgentConfig] = {}
+        self.reload()
+
+    def reload(self) -> None:
+        """Load persisted settings and rebuild the agents."""
+        settings = load_settings()
+        self.apply_settings(settings)
+
+    def apply_settings(self, settings: Dict[str, str]) -> None:
+        """Update settings and propagate them to all managed agents."""
+        self.settings = settings
+        self.agents = self._create_agents(settings)
+
+    def _create_agents(self, settings: Dict[str, str]) -> Dict[str, AgentConfig]:
+        """Construct the set of workflow agents requiring model credentials."""
+        agent_kwargs = {
+            "provider": settings.get("provider", DEFAULT_SETTINGS["provider"]),
+            "model_name": settings.get("model_name", DEFAULT_SETTINGS["model_name"]),
+            "api_key": settings.get("api_key", ""),
+            "base_url": settings.get("base_url") or None,
+        }
+        return {
+            "report_writer": AgentConfig(name="report_writer", **agent_kwargs),
+            "fact_checker": AgentConfig(name="fact_checker", **agent_kwargs),
+        }
+
+
+workflow_service = WorkflowService()
+
+
+def load_settings() -> Dict[str, str]:
+    """Return the persisted model settings or sensible defaults."""
+    if not CONFIG_FILE.exists():
+        return DEFAULT_SETTINGS.copy()
+
+    try:
+        with CONFIG_FILE.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return DEFAULT_SETTINGS.copy()
+
+    settings = DEFAULT_SETTINGS.copy()
+    settings.update({k: v for k, v in data.items() if k in settings})
+    return settings
+
+
+def save_settings(settings: Dict[str, str]) -> None:
+    """Persist the provided settings to the JSON configuration file."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with CONFIG_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(settings, fh, indent=2)
+
+
+app = Flask(__name__, template_folder="templates")
+app.secret_key = os.environ.get("APP_SECRET_KEY", "dev-secret-key")
+
+
+@app.route("/")
+def index():
+    """Homepage for the ESG Tool UI."""
+    return render_template("index.html", workflow=workflow_service)
+
+
+@app.route("/settings", methods=["GET", "POST"])
+def settings():
+    """Display and process the AI model settings form."""
+    current_settings = load_settings()
+
+    if request.method == "POST":
+        form_settings = {
+            "provider": request.form.get("provider", "").strip(),
+            "model_name": request.form.get("model_name", "").strip(),
+            "base_url": request.form.get("base_url", "").strip(),
+            "api_key": request.form.get("api_key", "").strip(),
+        }
+
+        errors = _validate_settings(form_settings)
+        if errors:
+            for error in errors:
+                flash(error, "error")
+            current_settings.update(form_settings)
+            return render_template(
+                "settings.html",
+                settings=current_settings,
+                available_models=AVAILABLE_MODELS,
+                selected_model_id=_detect_selected_model_id(form_settings),
+            ), 400
+
+        save_settings(form_settings)
+        workflow_service.apply_settings(form_settings)
+        flash("Model settings saved successfully.", "success")
+        return redirect(url_for("settings"))
+
+    return render_template(
+        "settings.html",
+        settings=current_settings,
+        available_models=AVAILABLE_MODELS,
+        selected_model_id=_detect_selected_model_id(current_settings),
+    )
+
+
+def _validate_settings(settings: Dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    if not settings.get("provider"):
+        errors.append("Provider is required.")
+    if not settings.get("model_name"):
+        errors.append("Model name is required.")
+    if not settings.get("api_key"):
+        errors.append("API key is required.")
+    return errors
+
+
+def _detect_selected_model_id(settings: Dict[str, str]) -> Optional[str]:
+    provider = settings.get("provider")
+    model_name = settings.get("model_name")
+    base_url = settings.get("base_url")
+    for model in AVAILABLE_MODELS:
+        if (
+            model["provider"] == provider
+            and model["model_name"] == model_name
+            and (model.get("base_url") or "") == (base_url or "")
+        ):
+            return model["id"]
+    return None
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/esg_tool/ui/templates/base.html
+++ b/esg_tool/ui/templates/base.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}ESG Tool{% endblock %}</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
+      crossorigin="anonymous"
+    >
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light border-bottom">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">ESG Tool</a>
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarNav"
+          aria-controls="navbarNav"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item">
+              <a class="nav-link{% if request.endpoint == 'index' %} active{% endif %}" href="{{ url_for('index') }}">Dashboard</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link{% if request.endpoint == 'settings' %} active{% endif %}" href="{{ url_for('settings') }}">AI Settings</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <main class="container py-4">
+      {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
+              {{ message }}
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>

--- a/esg_tool/ui/templates/index.html
+++ b/esg_tool/ui/templates/index.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard · ESG Tool{% endblock %}
+
+{% block content %}
+  <div class="py-5 text-center">
+    <h1 class="mb-3">ESG Workflow Dashboard</h1>
+    <p class="lead">Use the navigation bar to configure AI settings or access workflow features.</p>
+    <div class="mt-4">
+      <a class="btn btn-primary" href="{{ url_for('settings') }}">Configure AI model</a>
+    </div>
+  </div>
+{% endblock %}

--- a/esg_tool/ui/templates/settings.html
+++ b/esg_tool/ui/templates/settings.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+
+{% block title %}AI Model Settings · ESG Tool{% endblock %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-lg-8 col-xl-6">
+      <h1 class="mb-4">AI Model Settings</h1>
+      <p class="text-muted">Configure which language model the ESG workflow should use. You can start with one of the presets or provide a custom configuration.</p>
+      <form method="post" novalidate>
+        <div class="mb-3">
+          <label for="predefined_model" class="form-label">Preset</label>
+          <select class="form-select" id="predefined_model" name="predefined_model">
+            <option value="">Choose a preset…</option>
+            {% for model in available_models %}
+              <option value="{{ model.id }}" {% if model.id == selected_model_id %}selected{% endif %}>{{ model.label }}</option>
+            {% endfor %}
+            <option value="custom" {% if not selected_model_id %}selected{% endif %}>Custom configuration</option>
+          </select>
+          <div class="form-text">Selecting a preset fills in the provider, model name, and base URL fields below.</div>
+        </div>
+        <div class="mb-3">
+          <label for="provider" class="form-label">Provider <span class="text-danger">*</span></label>
+          <input type="text" class="form-control" id="provider" name="provider" value="{{ settings.provider }}" required>
+        </div>
+        <div class="mb-3">
+          <label for="model_name" class="form-label">Model name <span class="text-danger">*</span></label>
+          <input type="text" class="form-control" id="model_name" name="model_name" value="{{ settings.model_name }}" required>
+        </div>
+        <div class="mb-3">
+          <label for="base_url" class="form-label">Base URL</label>
+          <input type="url" class="form-control" id="base_url" name="base_url" value="{{ settings.base_url }}" placeholder="https://example.com/v1">
+          <div class="form-text">Leave blank if the provider has a default base URL.</div>
+        </div>
+        <div class="mb-3">
+          <label for="api_key" class="form-label">API key <span class="text-danger">*</span></label>
+          <input type="password" class="form-control" id="api_key" name="api_key" value="{{ settings.api_key }}" required>
+        </div>
+        <div class="d-flex gap-2">
+          <button type="submit" class="btn btn-primary">Save settings</button>
+          <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const presets = {{ available_models | tojson }};
+      const select = document.getElementById('predefined_model');
+      const providerInput = document.getElementById('provider');
+      const modelInput = document.getElementById('model_name');
+      const baseUrlInput = document.getElementById('base_url');
+
+      select.addEventListener('change', function (event) {
+        const selected = presets.find((model) => model.id === event.target.value);
+        if (selected) {
+          providerInput.value = selected.provider;
+          modelInput.value = selected.model_name;
+          baseUrlInput.value = selected.base_url || '';
+        }
+      });
+    });
+  </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Flask settings route that persists model configuration and refreshes workflow agents
- provide navigation and settings templates with presets and validation feedback
- surface flash messages for success and error states when updating the configuration

## Testing
- python -m compileall esg_tool

------
https://chatgpt.com/codex/tasks/task_e_68d89ec743a48320af3542f65c9eb0c6