### PR TITLE
Add UI to manage AI model configuration

### DIFF
--- a/esg_tool/ui/app.py
+++ b/esg_tool/ui/app.py
@@ -16,6 +16,12 @@ from flask import (
 )
 
 from esg_tool.models import CompanyProfile, ESGReportPackage, ProcessDocument
+from esg_tool.utils.configuration import (
+    AIModelConfig,
+    AISettings,
+    load_ai_settings,
+    save_ai_settings,
+)
 from esg_tool.utils.filesystem import ArchiveRepository
 from esg_tool.workflows.esg_workflow import ESGWorkflow
 
@@ -32,7 +38,18 @@ workflow = ESGWorkflow()
 def index():
     trace = workflow.debug_trace()
     packages = list(repository.list_packages())
-    return render_template("index.html", trace=trace, packages=packages)
+    ai_settings = load_ai_settings()
+    active_model_config = next(
+        (model for model in ai_settings.models if model.name == ai_settings.active_model),
+        None,
+    )
+    return render_template(
+        "index.html",
+        trace=trace,
+        packages=packages,
+        ai_settings=ai_settings,
+        active_model_config=active_model_config,
+    )
 
 
 @app.route("/start", methods=["GET", "POST"])
@@ -94,6 +111,183 @@ def review(package_id: str):
         flash("已记录确认信息，可继续下载成果。", "success")
         return redirect(url_for("review", package_id=package_id))
     return render_template("review.html", package=package)
+
+
+def _extract_model_entries(form) -> list[dict[str, str]]:
+    """Extract raw model entries from a submitted form."""
+
+    entries: list[dict[str, str]] = []
+    model_fields = [
+        "name",
+        "model_name",
+        "provider",
+        "api_base",
+        "api_key",
+        "temperature",
+        "max_tokens",
+        "timeout",
+    ]
+    indexes: set[str] = set()
+    for key in form.keys():
+        if key.startswith("models-"):
+            parts = key.split("-", 2)
+            if len(parts) == 3:
+                indexes.add(parts[1])
+    def _sort_key(value: str) -> int:
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+
+    for index in sorted(indexes, key=_sort_key):
+        entry = {"index": index}
+        for field in model_fields:
+            entry[field] = form.get(f"models-{index}-{field}", "").strip()
+        entries.append(entry)
+    return entries
+
+
+def _ensure_blank_entry(entries: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Ensure there is at least one blank entry for creating a new model."""
+
+    model_fields = [
+        "name",
+        "model_name",
+        "provider",
+        "api_base",
+        "api_key",
+        "temperature",
+        "max_tokens",
+        "timeout",
+    ]
+    for entry in entries:
+        if all(not entry.get(field) for field in model_fields):
+            return entries
+    existing_indexes = {
+        int(entry["index"]) for entry in entries if str(entry.get("index", "")).isdigit()
+    }
+    next_index = str(max(existing_indexes) + 1 if existing_indexes else 0)
+    blank_entry = {"index": next_index}
+    for field in model_fields:
+        blank_entry[field] = ""
+    entries.append(blank_entry)
+    return entries
+
+
+def _convert_to_configs(
+    entries: list[dict[str, str]],
+) -> tuple[list[AIModelConfig], dict[str, str], list[str]]:
+    """Convert raw form entries to model configs.
+
+    Returns a tuple of (configs, index_to_name, errors).
+    """
+
+    configs: list[AIModelConfig] = []
+    index_to_name: dict[str, str] = {}
+    errors: list[str] = []
+    for entry in entries:
+        index = entry.get("index", "")
+        # Skip completely empty entries
+        if all(not entry.get(field) for field in entry if field != "index"):
+            continue
+        name = entry.get("name", "").strip()
+        if not name:
+            errors.append(f"模型配置（序号 {index}）缺少显示名称")
+            continue
+        model_name = entry.get("model_name", "").strip() or name
+        provider = entry.get("provider", "").strip()
+        api_base = entry.get("api_base", "").strip()
+        api_key = entry.get("api_key", "").strip()
+        temperature_raw = entry.get("temperature", "").strip()
+        max_tokens_raw = entry.get("max_tokens", "").strip()
+        timeout_raw = entry.get("timeout", "").strip()
+
+        try:
+            temperature_value = float(temperature_raw) if temperature_raw else 0.7
+        except ValueError:
+            errors.append(f"模型 {name} 的温度值格式不正确，已重置为 0.7")
+            temperature_value = 0.7
+
+        try:
+            max_tokens_value = int(max_tokens_raw) if max_tokens_raw else 2048
+        except ValueError:
+            errors.append(f"模型 {name} 的最大 Token 数格式不正确，已重置为 2048")
+            max_tokens_value = 2048
+
+        try:
+            timeout_value = int(timeout_raw) if timeout_raw else None
+        except ValueError:
+            errors.append(f"模型 {name} 的超时参数格式不正确，已忽略")
+            timeout_value = None
+
+        config = AIModelConfig(
+            name=name,
+            model_name=model_name,
+            provider=provider,
+            api_base=api_base,
+            api_key=api_key,
+            temperature=temperature_value,
+            max_tokens=max_tokens_value,
+            timeout=timeout_value,
+        )
+        configs.append(config)
+        index_to_name[index] = config.name
+    return configs, index_to_name, errors
+
+
+@app.route("/settings", methods=["GET", "POST"])
+def settings():
+    settings_data = load_ai_settings()
+    if request.method == "POST":
+        raw_entries = _extract_model_entries(request.form)
+        configs, index_to_name, errors = _convert_to_configs(raw_entries)
+        selected_index = request.form.get("active_model")
+        for error in errors:
+            flash(error, "danger")
+        if not configs:
+            flash("请至少配置一个有效的 AI 模型。", "danger")
+            raw_entries = _ensure_blank_entry(raw_entries)
+            return render_template(
+                "settings.html",
+                models=raw_entries,
+                active_model_index=selected_index,
+                current_active=settings_data.active_model,
+            )
+        active_model = index_to_name.get(selected_index)
+        if not active_model:
+            active_model = configs[0].name
+        new_settings = AISettings(active_model=active_model, models=configs)
+        save_ai_settings(new_settings)
+        flash("AI 模型接口设置已更新。", "success")
+        return redirect(url_for("settings"))
+
+    models_for_form = []
+    for idx, model in enumerate(settings_data.models):
+        models_for_form.append(
+            {
+                "index": str(idx),
+                "name": model.name,
+                "model_name": model.model_name,
+                "provider": model.provider,
+                "api_base": model.api_base,
+                "api_key": model.api_key,
+                "temperature": str(model.temperature),
+                "max_tokens": str(model.max_tokens),
+                "timeout": "" if model.timeout is None else str(model.timeout),
+            }
+        )
+    models_for_form = _ensure_blank_entry(models_for_form)
+    active_index = None
+    for entry in models_for_form:
+        if entry.get("name") == settings_data.active_model:
+            active_index = entry.get("index")
+            break
+    return render_template(
+        "settings.html",
+        models=models_for_form,
+        active_model_index=active_index,
+        current_active=settings_data.active_model,
+    )
 
 
 @app.route("/packages/<package_id>/download/<artifact>")

--- a/esg_tool/ui/templates/base.html
+++ b/esg_tool/ui/templates/base.html
@@ -14,6 +14,7 @@
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item"><a class="nav-link" href="{{ url_for('start') }}">新建工作流</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('packages') }}">成果归档</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('settings') }}">AI 设置</a></li>
       </ul>
     </div>
   </div>

--- a/esg_tool/ui/templates/index.html
+++ b/esg_tool/ui/templates/index.html
@@ -12,6 +12,22 @@
       {% endfor %}
     </ol>
     <a class="btn btn-primary" href="{{ url_for('start') }}">开始新报告</a>
+    {% if active_model_config %}
+    <div class="alert alert-info mt-3">
+      <h5 class="alert-heading">默认 AI 模型</h5>
+      <p class="mb-1"><strong>{{ active_model_config.name }}</strong>（{{ active_model_config.model_name }}）</p>
+      <p class="mb-2 small text-muted">提供方：{{ active_model_config.provider or '未设置' }}，接口地址：{{ active_model_config.api_base or '未设置' }}</p>
+      <div class="d-flex justify-content-between align-items-center">
+        <span class="small">温度：{{ active_model_config.temperature }}，最大 Token：{{ active_model_config.max_tokens }}</span>
+        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('settings') }}">管理模型设置</a>
+      </div>
+    </div>
+    {% else %}
+    <div class="alert alert-warning mt-3 d-flex justify-content-between align-items-center">
+      <span>尚未配置默认的 AI 模型。</span>
+      <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('settings') }}">立即配置</a>
+    </div>
+    {% endif %}
   </div>
   <div class="col-md-5">
     <div class="card">

--- a/esg_tool/ui/templates/settings.html
+++ b/esg_tool/ui/templates/settings.html
@@ -1,0 +1,67 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-3">AI 模型接口设置</h1>
+<p class="text-muted">配置可用的 AI 模型接口参数，包括名称、供应商、接口地址以及默认生成参数。
+保存后，平台将在工作流中优先使用默认勾选的模型。</p>
+<form method="post">
+  <div class="mb-4">
+    <span class="form-text">如需新增模型，可填写下方空白表单；若要删除模型，请清空对应信息后保存。</span>
+  </div>
+  {% for model in models %}
+  <div class="card mb-3 shadow-sm">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span>模型配置 {{ loop.index }}</span>
+      <div class="form-check">
+        <input class="form-check-input" type="radio" name="active_model" id="active_model_{{ model.index }}" value="{{ model.index }}" {% if active_model_index == model.index %}checked{% endif %}>
+        <label class="form-check-label" for="active_model_{{ model.index }}">设为默认</label>
+      </div>
+    </div>
+    <div class="card-body">
+      <div class="row g-3">
+        <div class="col-md-4">
+          <label class="form-label" for="model_name_{{ model.index }}">显示名称</label>
+          <input type="text" class="form-control" id="model_name_{{ model.index }}" name="models-{{ model.index }}-name" value="{{ model.name }}" placeholder="例如：内部 GPT-4.1 接口">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="model_code_{{ model.index }}">模型标识</label>
+          <input type="text" class="form-control" id="model_code_{{ model.index }}" name="models-{{ model.index }}-model_name" value="{{ model.model_name }}" placeholder="例如：gpt-4.1">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="model_provider_{{ model.index }}">供应商</label>
+          <input type="text" class="form-control" id="model_provider_{{ model.index }}" name="models-{{ model.index }}-provider" value="{{ model.provider }}" placeholder="例如：OpenAI">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="model_base_{{ model.index }}">接口地址</label>
+          <input type="text" class="form-control" id="model_base_{{ model.index }}" name="models-{{ model.index }}-api_base" value="{{ model.api_base }}" placeholder="https://api.example.com/v1">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="model_key_{{ model.index }}">API Key</label>
+          <input type="text" class="form-control" id="model_key_{{ model.index }}" name="models-{{ model.index }}-api_key" value="{{ model.api_key }}" placeholder="仅在本地保存">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="model_temperature_{{ model.index }}">温度</label>
+          <input type="number" step="0.1" min="0" max="2" class="form-control" id="model_temperature_{{ model.index }}" name="models-{{ model.index }}-temperature" value="{{ model.temperature }}">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="model_tokens_{{ model.index }}">最大 Token</label>
+          <input type="number" min="0" class="form-control" id="model_tokens_{{ model.index }}" name="models-{{ model.index }}-max_tokens" value="{{ model.max_tokens }}">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="model_timeout_{{ model.index }}">超时（秒，可选）</label>
+          <input type="number" min="0" class="form-control" id="model_timeout_{{ model.index }}" name="models-{{ model.index }}-timeout" value="{{ model.timeout }}">
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+  <div class="d-flex justify-content-end gap-2">
+    <a class="btn btn-outline-secondary" href="{{ url_for('index') }}">返回首页</a>
+    <button class="btn btn-primary" type="submit">保存设置</button>
+  </div>
+</form>
+{% if current_active %}
+<div class="alert alert-light border mt-4">
+  当前默认模型：<strong>{{ current_active }}</strong>。
+</div>
+{% endif %}
+{% endblock %}

--- a/esg_tool/utils/configuration.py
+++ b/esg_tool/utils/configuration.py
@@ -1,0 +1,133 @@
+"""Configuration helpers for AI model settings."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+CONFIG_PATH = BASE_DIR / "storage" / "ai_settings.json"
+
+
+@dataclass
+class AIModelConfig:
+    """Connection and parameter configuration for an AI model."""
+
+    name: str
+    model_name: str
+    provider: str
+    api_base: str
+    api_key: str
+    temperature: float = 0.7
+    max_tokens: int = 2048
+    timeout: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AIModelConfig":
+        temperature = _safe_float(data.get("temperature"), default=0.7)
+        max_tokens = _safe_int(data.get("max_tokens"), default=2048)
+        timeout = _safe_int(data.get("timeout"), default=None)
+        return cls(
+            name=data.get("name", ""),
+            model_name=data.get("model_name") or data.get("name", ""),
+            provider=data.get("provider", ""),
+            api_base=data.get("api_base", ""),
+            api_key=data.get("api_key", ""),
+            temperature=temperature if temperature is not None else 0.7,
+            max_tokens=max_tokens if max_tokens is not None else 2048,
+            timeout=timeout,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        if self.timeout is None:
+            data.pop("timeout", None)
+        return data
+
+
+@dataclass
+class AISettings:
+    """Container for all available AI model configurations."""
+
+    active_model: str
+    models: List[AIModelConfig]
+
+    @classmethod
+    def default(cls) -> "AISettings":
+        default_model = AIModelConfig(
+            name="默认模型",
+            model_name="gpt-4",
+            provider="openai",
+            api_base="https://api.openai.com/v1",
+            api_key="",
+            temperature=0.7,
+            max_tokens=2048,
+            timeout=None,
+        )
+        return cls(active_model=default_model.name, models=[default_model])
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "active_model": self.active_model,
+            "models": [model.to_dict() for model in self.models],
+        }
+
+
+def load_ai_settings(path: Path | None = None) -> AISettings:
+    """Load AI settings from disk or return defaults when missing."""
+
+    settings_path = path or CONFIG_PATH
+    if settings_path.exists():
+        try:
+            data = json.loads(settings_path.read_text("utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return AISettings.default()
+        models_data = data.get("models") or []
+        models = [AIModelConfig.from_dict(model) for model in models_data]
+        if not models:
+            default_settings = AISettings.default()
+            save_ai_settings(default_settings, path=settings_path)
+            return default_settings
+        active_model = data.get("active_model") or models[0].name
+        if active_model not in {model.name for model in models}:
+            active_model = models[0].name
+        return AISettings(active_model=active_model, models=models)
+    default_settings = AISettings.default()
+    save_ai_settings(default_settings, path=settings_path)
+    return default_settings
+
+
+def save_ai_settings(settings: AISettings, path: Path | None = None) -> None:
+    """Persist AI settings to disk as JSON."""
+
+    settings_path = path or CONFIG_PATH
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = settings.to_dict()
+    settings_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), "utf-8")
+
+
+def _safe_float(value: Any, default: float | None = None) -> float | None:
+    if value is None or value == "":
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(value: Any, default: int | None = None) -> int | None:
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+__all__ = [
+    "AIModelConfig",
+    "AISettings",
+    "load_ai_settings",
+    "save_ai_settings",
+]


### PR DESCRIPTION
## Summary
- add utilities to persist AI model configuration in storage
- expose a new Flask settings route and form to manage model options and defaults
- surface the active AI model in the navigation and dashboard

## Testing
- python -m compileall esg_tool

------
https://chatgpt.com/codex/tasks/task_e_68d8ebfc95a48320b4903008aa306bc3